### PR TITLE
Add the support of Ankiconnect v5 (2018-01-15)

### DIFF
--- a/ext/bg/js/options-form.js
+++ b/ext/bg/js/options-form.js
@@ -110,7 +110,7 @@ function updateAnkiStatus() {
         if (version === null) {
             $('.error-dlg-connection').show();
             $('.options-anki-controls').hide();
-        } else if (version !== yomichan().getApiVersion()) {
+        } else if (version > yomichan().getApiVersion()) {
             $('.error-dlg-version').show();
             $('.options-anki-controls').hide();
         } else {

--- a/ext/bg/js/yomichan.js
+++ b/ext/bg/js/yomichan.js
@@ -129,7 +129,7 @@ class Yomichan {
     }
 
     getApiVersion() {
-        return 2;
+        return 5;
     }
 
     tabInvokeAll(action, params) {


### PR DESCRIPTION
Ankiconnect states that its APIs are compatible with older versions, so loose the version limit here.

> New versions of AnkiConnect are backwards compatible